### PR TITLE
Added avg length of disasters per year

### DIFF
--- a/docs/disasters.md
+++ b/docs/disasters.md
@@ -55,6 +55,7 @@ import {
   getConfirmedAffectedPersonsPerYear,
   getDisastersAmountPerCountryPerYear,
   getTypeCorrelations,
+  getAverageLengthOfDisasterPerYear,
 } from "./process_data.js";
 
 const emdat_disasters = await FileAttachment("data/emdat_disasters.csv").csv({
@@ -62,9 +63,10 @@ const emdat_disasters = await FileAttachment("data/emdat_disasters.csv").csv({
   headers: true,
 });
 
-const groupedDisasters = getGroupedDisasters(emdat_disasters)
-const disastersPerYear = getDisastersPerYear(emdat_disasters)
-const confirmedAffectedPersonsPerYear = getConfirmedAffectedPersonsPerYear(emdat_disasters)
+const groupedDisasters = getGroupedDisasters(emdat_disasters);
+const disastersPerYear = getDisastersPerYear(emdat_disasters);
+const confirmedAffectedPersonsPerYear =
+  getConfirmedAffectedPersonsPerYear(emdat_disasters);
 
 const counts = Object.keys(groupedDisasters)
   .reduce((acc, key) => {
@@ -73,9 +75,15 @@ const counts = Object.keys(groupedDisasters)
   }, [])
   .sort((a, b) => b.amount - a.amount);
 
- const totalCount = counts.reduce((acc, dic) => acc + dic["amount"], 0);
- const disastersAmountPerCountryPerYear = getDisastersAmountPerCountryPerYear(emdat_disasters);
- const correlations = getTypeCorrelations(disastersAmountPerCountryPerYear, emdat_disasters);
+const totalCount = counts.reduce((acc, dic) => acc + dic["amount"], 0);
+const disastersAmountPerCountryPerYear =
+  getDisastersAmountPerCountryPerYear(emdat_disasters);
+const correlations = getTypeCorrelations(
+  disastersAmountPerCountryPerYear,
+  emdat_disasters
+);
+const averageLengthOfDisasterPerYear =
+  getAverageLengthOfDisasterPerYear(emdat_disasters);
 ```
 
 ```js
@@ -147,6 +155,13 @@ const selectedAndColor = getDisastersPerColor(selectedDisasters);
 <div class="grid grid-cols-2" style="grid-auto-rows: 600px;">
   <div class="card">
     ${correlationMatrix(correlations)}
+  </div>
+</div>
+
+<div class="grid grid-cols-2" style="grid-auto-rows: 600px;">
+  <div class="card">
+    ${lineChart(averageLengthOfDisasterPerYear.filter(disaster => selectedDisasters.includes(disaster["disaster"])),
+            "avgLength", "Length of disaster", selectedAndColor)}
   </div>
 </div>
 ---

--- a/docs/process_data.js
+++ b/docs/process_data.js
@@ -150,7 +150,7 @@ export function getTypeCorrelations(disastersAmountPerCountryPerYear, emdat_disa
 }
 
 export function getConfirmedAffectedPersonsPerYear(disasters){
-    const groupedDisasters = getGroupedDisasters(disasters)
+    const groupedDisasters = getGroupedDisasters(disasters);
     return Object.entries(groupedDisasters).reduce((acc, [disasterType, disasterList]) => {
 
         let json = {};
@@ -221,4 +221,54 @@ export function getTotalDisastersPerCountry(disasters) {
             acc.push({country: country, ...disastersForCountry});
             return acc;
         }, []);
+}
+
+
+export function getAverageLengthOfDisasterPerYear(disasters) {
+  const groupedDisasters = getGroupedDisasters(disasters);
+  return Object.entries(groupedDisasters).reduce((acc, [disasterType, disasterList]) => {
+    let obj = new Object();
+    let miny = Number.MAX_VALUE;
+    let maxy = Number.MIN_VALUE;
+  
+    disasterList.forEach(d => {
+      const startYear = parseInt(d["Start Year"]);
+      const startMonth = parseInt(d["Start Month"]);
+      const startDay = parseInt(d["Start Day"]);
+  
+      const endYear = parseInt(d["End Year"]);
+      const endMonth = parseInt(d["End Month"]);
+      const endDay = parseInt(d["End Day"]);
+  
+      const hasNan = [startYear, startMonth, startDay, endYear, endMonth, endDay].some(el => isNaN(el))
+      if (hasNan) return;
+      
+      const startDate = new Date(startYear, startMonth, startDay);
+      const endDate = new Date(endYear, endMonth, endDay);
+  
+      const lengthInDays = Math.round((endDate - startDate) / (1000 * 60 * 60 * 24));
+      if (startYear in obj) {
+          const [currentAvg, n] = obj[startYear];
+          const newAvg = (lengthInDays + currentAvg * n) / (n + 1);
+          obj[startYear] = [newAvg, n + 1];
+      } else {
+          obj[startYear] = [lengthInDays, 1];
+      }
+  
+      if (startYear < miny) {
+        miny = startYear;
+      }
+      if (startDate > maxy) {
+        maxy = startYear;
+      }
+    });
+    for (let i = miny; i < maxy; i++) {
+      let avgLength = 0;
+      if (i in obj) {
+          avgLength = obj[i][0];
+      }
+      acc.push({disaster: disasterType, year : i, avgLength: avgLength});
+    }
+  return acc;
+  }, []);
 }


### PR DESCRIPTION
Adds the average length of a disaster per year. This shows another way of how intense a disaster is.
Example: You can see that the droughts are longer in duration.